### PR TITLE
mbr: comments out login spinner on home page

### DIFF
--- a/src/app/home/home.page.ts
+++ b/src/app/home/home.page.ts
@@ -36,9 +36,9 @@ export class HomePage implements OnInit {
 
   ionViewWillEnter() {
     this._pictureService.init();
-    this._loadingService.show({message: "..loading.."}).then(() => {
-
-    })
+    // this._loadingService.show({message: "..loading.."}).then(() => {
+        // Do Nothing
+    // })
   }
 
   getAssociatedImageCSS(topic) {


### PR DESCRIPTION
- reasoning: when launching the app to test code, the login spinner spins indefintiely on the home page and prevents any further actions. Tribe App's home page currently does this same thing.