### PR TITLE
TRIB-268: refactors picture service save()

### DIFF
--- a/src/app/_services/picture/picture.service.ts
+++ b/src/app/_services/picture/picture.service.ts
@@ -131,30 +131,34 @@ export class PictureService {
   }
 
   save(photoType, model) {
-    let self = this;
+    return new Promise(async (resolve, reject) => {
+      const blob = await fetch(model["imageWebPath"]).then(r => r.blob());
 
-    return new Promise((resolve, reject) => {
+      const formData = new FormData();
+      formData.append('file', blob, model["imageWebPath"]);
 
-      const uploadImageToAPI = async () => {
-        const blob = await fetch(model["imageWebPath"]).then(r => r.blob());
+      const url = environment.apiUrl + "/api/resource/" + photoType + "/" + model["id"];
 
-        const formData = new FormData();
-        formData.append('file', blob, model["imageWebPath"]);
-
-        const url = environment.apiUrl + "/api/resource/" + photoType + "/" + model["id"];
-
-        self._apiService.post(url, formData)
-            .subscribe(res => {
-              if (res['responseMessage'] === 'ok') {
-                resolve(true);
-              } else {
-                reject("error posting image to server");
-              }
-            });
-      };
-
-      uploadImageToAPI();
-    })
+      fetch(url, {
+        method: 'POST',
+        headers: {
+          'Authorization': 'Bearer ' + this._authService.getToken()
+        },
+        body: formData
+      })
+          .then(response => response.json()) // Assuming the response is in JSON format
+          .then(data => {
+            if (data['responseMessage'] === 'ok') {
+              //this.logger.debug('File uploaded successfully')
+              resolve(data); // Resolve the promise if the response message is 'ok'
+            } else {
+              reject(new Error('Server responded with an error: ' + data['responseMessage']));
+            }
+          })
+          .catch(error => {
+            reject(new Error('Network error or server is unreachable: ' + error.message));
+          });
+    });
   }
 
   getAssociatedImage(photoType, model, photoSize) {


### PR DESCRIPTION
- ports picture fix from TRIBE to base project
- fixes "not a multipart file" error on backend (Jonathan discovered that this function needs to use "fetch")

Note: You (Jonathan) sent me code from the convo app. This is nearly identical, with the exception that the base app was updated to receive a return object instead of just text. I updated the variables from data.msg to data['responseMessage']. I also left the logger message from the convo app code (commented out)

Testing:
Functions as expected when running front end / back end, except that the new image is not immediately available on the profile page. I had to log out as that user and log back in to see the new image.